### PR TITLE
When setting keys in ECB mode, don't check IV length.

### DIFF
--- a/lib/src/aes.dart
+++ b/lib/src/aes.dart
@@ -196,7 +196,7 @@ class _Aes {
       throw AesCryptArgumentError('Invalid key length for AES. Provided ${key.length * 8} bits, expected 128, 192 or 256 bits.');
     } else if (_aesMode != AesMode.ecb && iv.isNullOrEmpty) {
       throw AesCryptArgumentError('The initialization vector is not specified. It can not be empty when AES mode is not ECB.');
-    } else if (iv.length != 16) {
+    } else if (_aesMode != AesMode.ecb && iv.length != 16) {
       throw AesCryptArgumentError('Invalid IV length for AES. The initialization vector must be 128 bits long.');
     }
 


### PR DESCRIPTION
I was trying to encrypt a string using a generated key and no IV because I'm using ECB. Here's my code:
```
var crypt = AesCrypt();
crypt.aesSetMode(AesMode.ecb);
Uint8List key = crypt.createKey();
crypt.aesSetKeys(key);
...
```
When I go to set the key it fails giving this error:
`Unhandled Exception: NoSuchMethodError: The getter 'length' was called on null.`

With this partial stack trace:
```

E/flutter ( 7509): #1      _Aes.aesSetKeys          package:aes_crypt/src/aes.dart:199
E/flutter ( 7509): #2      AesCrypt.aesSetKeys      package:aes_crypt/src
...
```

Following this trace to `aes_crypt/src/aes.dart:199` I find this code: https://github.com/alexgoussev/aes_crypt/blob/68cb8f74705d46f060d30b237dd19f4b7170a763/lib/src/aes.dart#L199

It checks the length of the IV even in ECB mode when ECB mode doesn't require an IV (if my understanding is correct).
I've made this check only occur when the mode is not ECB.